### PR TITLE
FIX -  Resource references should be capitalized

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,13 +54,13 @@ class vsftpd (
 ) inherits ::vsftpd::params {
   package { $package_name: ensure => installed }
   file { $configfile:
-    require => package[$package_name],
+    require => Package[$package_name],
     backup  => '.backup',
     content => template($template),
   }
   if $::osfamily == 'RedHat' {
     service { 'vsftpd':
-      require => package[$package_name],
+      require => Package[$package_name],
       enable  => true,
     }
   }


### PR DESCRIPTION
Warning: Deprecation notice:  Resource references should now be capitalized on line 57 in file /etc/puppet/modules/vsftpd/manifests/init.pp  
Warning: Deprecation notice:  Resource references should now be capitalized on line 63 in file /etc/puppet/modules/vsftpd/manifests/init.pp